### PR TITLE
Redirect root endpoint to `/home` endpoint [VOS-7]

### DIFF
--- a/src/Controller/RootController.php
+++ b/src/Controller/RootController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+
+final class RootController extends AbstractController
+{
+    #[Route(
+        path: '/',
+        name: 'root_index',
+        methods: ['GET']
+    )]
+    public function index(): Response
+    {
+        return $this->render(
+            view: 'root/index.html.twig',
+            parameters: [
+                'controller_name' => 'RootController',
+            ]
+        );
+    }
+}

--- a/templates/root/index.html.twig
+++ b/templates/root/index.html.twig
@@ -1,0 +1,39 @@
+{% extends 'base.html.twig' %}
+
+
+{% block title %}VOS | Home{% endblock %}
+
+
+{% block body %}
+<style>
+    .example-wrapper {
+        margin: 1em auto;
+        max-width: 800px;
+        width: 95%;
+        font: 18px/1.5 sans-serif;
+    }
+    .example-wrapper code {
+        background: #F5F5F5;
+        padding: 2px 6px;
+    }
+</style>
+
+
+<div class="example-wrapper">
+    <h1>
+        Hello
+        <code>{{ app.user.username ?? 'Anonymous User' }}</code>
+        from
+        <code>{{ controller_name }}</code>
+        rendered under
+        <code>{{ app.current_route }}</code>
+        route name!
+    </h1>
+
+    This friendly message is coming from:
+    <ul>
+        <li>Your controller at <code>C:/Users/kutec/Documents/Workplace/VOS Folders/VOS/src/Controller/RootController.php</code></li>
+        <li>Your template at <code>C:/Users/kutec/Documents/Workplace/VOS Folders/VOS/templates/root/index.html.twig</code></li>
+    </ul>
+</div>
+{% endblock %}

--- a/tests/Controller/RootControllerTest.php
+++ b/tests/Controller/RootControllerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+
+final class RootControllerTest extends WebTestCase
+{
+    public function testIndex(): void
+    {
+        $client = static::createClient();
+        $client->request(
+            method: 'GET',
+            uri: '/home'
+        );
+
+        self::assertResponseIsSuccessful();
+    }
+}


### PR DESCRIPTION
## ✅ What

Allow users to just type in the website URL and see the same page content as if they explicitly type in the `/home` path.

## 🤔 Why

Because users (non-technical users specifically) don't give a fudge about having `/home` endpoint or not. All they need to see is the **Home page**, or **Landing page** to be more fancy wording.

## 👩‍🔬 How to validate

1. **New page**
- Very simple, either type in [localhost:8001](http://localhost:8001), [localhost:8001/](http://localhost:8001/), or [localhost:8001/home](http://localhost:8001/home).

2. **Test file**
- Get inside `vos-symfony` container by executing `docker exec -it vos-symfony sh`. Then, execute `php bin/phpunit tests/` to run the test file.

## 🔖 Related

- **GitHub Project ticket**: [VOS-7](https://github.com/users/FaceWithDark/projects/4/views/1?pane=issue&itemId=192569930)