### PR TITLE
Setup GitHub Issues template [VOS-8]

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,26 @@
+## Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See the error.
+
+## Expected Behavior
+
+<!-- Explain what you expected to happen. -->
+
+## Screenshots
+
+<!-- Add screenshots if applicable. -->
+
+## Environment
+
+- OS: `e.g., Windows, macOS, Linux`
+- Browser: `e.g., Chrome, Firefox`
+
+## Additional Context
+
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
## ✅ What

Enforce devs to use **GitHub Issues** template format for this project.

## 🤔 Why

Because I don't want to see gazillion format spamming at my screen when I've to review all of them since I'm the only maintainer for this project.

## 👩‍🔬 How to validate

I don't think we can test it directly since this only usable until we merged to `main` branch according to [GitHub Docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository). Therefore, just check on the format to see if it's needed to be modify anywhere.

## 🔖 Related

- GitHub Project ticket: [VOS-8](https://github.com/users/FaceWithDark/projects/4/views/1?pane=issue&itemId=192559101)