### PR TITLE
Add documentation file about convention that this project follows for each git commits [VOS-9]

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ docker exec -it vos-symfony sh
 # Run the `phpunit` binary file to do different kinds of testing techniques
 php bin/phpunit tests/
 ```
+
+---
+# Conventions
+
+> [!TIP]
+> You know it's a good and well maintained project if they've a dedicated section these kind of stuffs.
+
+There're many conventions that this project followed to ensure that it's not a big of a burden for someone else (e.g., current devs, maintainers, reviewers, etc) when they've to touch on things that almost no one willing to do it. If you want to be a good contributor/dev, please take a look and follow them accordingly here:
+
+1. [**Git Commit Convention**](./docs/conventions/GIT.md)

--- a/docs/conventions/GIT.md
+++ b/docs/conventions/GIT.md
@@ -1,0 +1,11 @@
+# VOS Git Commit Convention Guideline
+This project strictly follows [**Convential Commit**](https://www.conventionalcommits.org/en/v1.0.0/) style for each Git commit pushed with some custom tags defined by us so that it matches our workflow. These including:
+
+1. `init`: for commits that set a new default setup to the project. This could be: repo structure, **Docker Compose** setup, etc.
+2. `chore`: for commits that doesn't fit with all other tags. This one would be the one to be used a lot if you unsure what tags to use.
+3. `feat`: for commits that propose a new feature, implmentation, etc
+4. `doc`: for commits that update/add documentation files. This's mostly used for file under `/docs` directory or those `.md` file at project root directory.
+5. `fix`: for commits that resolve submitted bugs/issues from [**GitHub Issues**](https://github.com/FaceWithDark/VOS/issues) page.
+6. `revert`: for commits that pushed back changes that shouldn't be allowed/approved to one of the core branches. This can be used to revert changes in `main` branch if latest PR to `main` 'cause serious problems on production evironment.
+7. `docker`: for commits that update files related to **Docker** setup, or add/modify new/current `Dockerfile` file if needed as the complexity of the project goes on.
+8. `review`: for commits that resolve reviews received during any created PR. Please use this with a very minimal info provided right next to the tag so that we can differenciate which sort of review is/are this when backtracking (e.g., `review(new-service)`).


### PR DESCRIPTION
## ✅ What

New **Git Commit Convention** documentation file.

## 🤔 Why

Because I want a consistent git commit history so that when backtracking works/issues, it's a lot more clear on the purpose of each commit being pushed. This also helps me reduce the amount of possible swearing coming out from my mouth when I'm the one having to do the work that no one want to do **(YOU KNOW WHAT IT IS)**.

## 👩‍🔬 How to validate

Are you seriously ask this question? Just... read the new documentation file and give me some feedbacks on it?

## 🔖 Related

- GitHub Project ticket: [VOS-9](https://github.com/users/FaceWithDark/projects/4?pane=issue&itemId=192570724)