### PR TITLE
New Twig pages for `/` & `/home` path [VOS-11-2]

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -133,24 +133,3 @@ code {
     line-height: var(--mono-lh);
     background-color: var(--surface);
 }
-
-
-/*
- * By default, standard browser engines do not inherit these on form inputs,
- * textareas, selectors, or buttons. Therefore, we've to explicitly set it
- */
-button,
-input,
-select,
-textarea {
-    font-family: inherit;
-    font-size: inherit;
-    font-weight: inherit;
-    line-height: inherit;
-    color: inherit;
-}
-
-
-a {
-    color: var(--primary);
-}

--- a/assets/styles/components/nav.css
+++ b/assets/styles/components/nav.css
@@ -1,3 +1,8 @@
 nav {
     background-color: var(--surface);
 }
+
+
+nav div a {
+    color: var(--primary);
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -18,9 +18,9 @@
         <script src="https://cdn.jsdelivr.net/npm/frankenphp-hot-reload/+esm" type="module"></script>
         {% endif %}
     </head>
-    <body>
+    <body class="flex flex-col min-h-screen">
         {% block body %}
-            <nav class="flex flex-row justify-around">
+            <nav class="flex flex-row justify-around flex-none">
                 <div class="flex flex-row items-center-safe" id="nav-left">
                     <a href="{{ path(name: 'home_index')}}">Home</a>
                 </div>
@@ -36,7 +36,7 @@
                 </div>
             </nav>
 
-            <main>
+            <main class="flex flex-col flex-auto">
                 {% block content %}{% endblock %}
             </main>
         {% endblock %}

--- a/templates/root/index.html.twig
+++ b/templates/root/index.html.twig
@@ -5,6 +5,13 @@
 
 
 {% block page_contents %}
-    <h1>VOS</h1>
-    <p>Iaculis augue, est non, dis dolor id maximus est nulla.</p>
+    <header class="flex flex-col justify-evenly items-center-safe" id="home-page-title">
+        <h1 class="p-12">VOS</h1>
+        <h2 class="p-12">Manage osu!taiko tournament with ease</h2>
+        <h3 class="p-12">A clean website that simplify to your workflow</h3>
+    </header>
+
+    <aside class="flex flex-row justify-center-safe" id="home-page-info">
+        <a href="#" class="text-(--accent) border-solid rounded-full border-2 border-(--border) p-3">Discover more</a>
+    </aside>
 {% endblock %}

--- a/templates/root/layout.html.twig
+++ b/templates/root/layout.html.twig
@@ -2,5 +2,7 @@
 
 
 {% block content %}
-    {% block page_contents %}{% endblock %}
+    <div class="flex flex-col flex-auto justify-center-safe" id="home-page">
+        {% block page_contents %}{% endblock %}
+    </div>
 {% endblock %}


### PR DESCRIPTION
## ✅ What

New design for **Home page** when access either `/` or `/home` path.

## 🤔 Why

Because we want people to get exicted when they get to hear about our services and wanted to test out by visiting the website. Right now, the default look is terrible to even begin with, hence an absolute new design is crucially needed.

## 👩‍🔬 How to validate

Go to website URL ([localhost:8001](http://localhost:8001), or [localhost:8001/home](http://localhost:8001/home)) to see the new design.

## 🔖 Related

- GitHub Project ticket: [VOS-11-2](https://github.com/users/FaceWithDark/projects/4/views/1?pane=issue&itemId=199751903)