### PR TITLE
Update `.giattributes` to cover more cases [VOS-15]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,152 +1,310 @@
-# Auto detect
-##   Handle line endings automatically for files detected as
-##   text and leave all files detected as binary untouched.
-##   This will handle all files NOT defined below.
-*         text=auto
+### Credits ###
 
-# PHP files
-*.php           text eol=lf diff=php
-*.phpt          text eol=lf diff=php
-*.phtml         text eol=lf diff=html
-*.twig          text eol=lf
-*.phar          binary
 
-# Configuration
-phpcs.xml       text eol=lf
-phpunit.xml     text eol=lf
-phpstan.neon    text eol=lf
-psalm.xml       text eol=lf
+## [VisualStudio.gitattributes](https://github.com/gitattributes/gitattributes/blob/master/Global/VisualStudio.gitattributes) ##
+
+
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+*            text=auto
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just comment the entries below and
+# uncomment the group further below
+###############################################################################
+*.sln        text eol=crlf
+*.csproj     text eol=crlf
+*.vbproj     text eol=crlf
+*.vcxproj    text eol=crlf
+*.vcproj     text eol=crlf
+*.dbproj     text eol=crlf
+*.fsproj     text eol=crlf
+*.lsproj     text eol=crlf
+*.wixproj    text eol=crlf
+*.modelproj  text eol=crlf
+*.sqlproj    text eol=crlf
+*.wwaproj    text eol=crlf
+
+*.xproj      text eol=crlf
+*.props      text eol=crlf
+*.filters    text eol=crlf
+*.vcxitems   text eol=crlf
+
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+#*.xproj     merge=binary
+#*.props     merge=binary
+#*.filters   merge=binary
+#*.vcxitems  merge=binary
+
+
+## [VisualStudioCode.gitattributes](https://github.com/gitattributes/gitattributes/blob/master/Global/VisualStudioCode.gitattributes) ##
+
+
+# Fix syntax highlighting on GitHub to allow comments
+.vscode/*.json linguist-language=JSON-with-Comments
+
+
+### This one is a mix of multiple `.gitattributes` since it kinds of conflict each other ###
+
+
+## 1. [Common.gitattributes](https://github.com/gitattributes/gitattributes/blob/master/Common.gitattributes) ##
+## 2. [Markdown.gitattributes](https://github.com/gitattributes/gitattributes/blob/master/Markdown.gitattributes) ##
+## 3. [PHP.gitattributes](https://github.com/gitattributes/gitattributes/blob/master/PHP.gitattributes) ##
+## 4. [PowerShell.gitattributes](https://github.com/gitattributes/gitattributes/blob/master/PowerShell.gitattributes) ##
+## 5. [Web.gitattributes](https://github.com/gitattributes/gitattributes/blob/master/Web.gitattributes) ##
+
+
+## GITATTRIBUTES FOR WEB PROJECTS
+#
+# These settings are for any web project.
+#
+# Details per file setting:
+#   text    These files should be normalized (i.e. convert CRLF to LF).
+#   binary  These files are binary and should be left untouched.
+#
+# Note that binary is a macro for -text -diff.
+######################################################################
 
 # Source code
-*.bash          text eol=lf
-*.bat           text eol=crlf
-*.cmd           text eol=crlf
-*.json          text
-*.ps1           text eol=crlf
-*.py            text diff=python
-*.sh            text eol=lf
-*.sql           text
+*.bash            text eol=lf
+*.bat             text eol=crlf
+*.cmd             text eol=crlf
+*.coffee          text
+*.css             text diff=css
+*.htm             text diff=html
+*.html            text diff=html
+*.inc             text
+*.ini             text
+*.js              text
+*.mjs             text
+*.cjs             text
+*.json            text
+*.jsx             text
+*.less            text
+*.ls              text
+*.map             text -diff
+*.od              text
+*.onlydata        text
+*.pl              text
+*.py              text diff=python
+*.rb              text diff=ruby
+*.sass            text
+*.scm             text
+*.scss            text diff=css
+*.sh              text eol=lf
+.husky/*          text eol=lf
+*.sql             text
+*.styl            text
+*.tag             text
+*.ts              text
+*.tsx             text
+*.xml             text
+*.xhtml           text diff=html
 
 # Docker
-Dockerfile      text
+Dockerfile        text
 
 # Documentation
-*.ipynb         text eol=lf
-*.markdown      text diff=markdown
-*.md            text diff=markdown
-*.mdwn          text diff=markdown
-*.mdown         text diff=markdown
-*.mkd           text diff=markdown
-*.mkdn          text diff=markdown
-*.mdtxt         text
-*.mdtext        text
-*.txt           text eol=lf
-AUTHORS         text
-CHANGELOG       text
-CHANGES         text
-CONTRIBUTING    text
-COPYING         text
-copyright       text
-*COPYRIGHT*     text
-INSTALL         text
-license         text
-LICENSE         text
-NEWS            text
-readme          text
-*README*        text
-TODO            text
+*.ipynb           text eol=lf
+*.markdown        text diff=markdown
+*.mdwn            text diff=markdown
+*.mdown           text diff=markdown
+*.mkd             text diff=markdown
+*.mkdn            text diff=markdown
+*.mdtxt           text
+*.mdtext          text
+*.txt             text eol=lf
+AUTHORS           text
+CHANGELOG         text
+CHANGES           text
+CONTRIBUTING      text
+COPYING           text
+copyright         text
+*COPYRIGHT*       text
+INSTALL           text
+license           text
+LICENSE           text
+NEWS              text
+readme            text
+*README*          text
+TODO              text
+
+# Templates
+*.dot             text
+*.ejs             text
+*.erb             text
+*.haml            text
+*.handlebars      text
+*.hbs             text
+*.hbt             text
+*.jade            text
+*.latte           text
+*.mustache        text
+*.njk             text
+*.phtml           text
+*.svelte          text
+*.tmpl            text
+*.tpl             text
+*.twig            text
+*.vue             text
 
 # Configs
-*.cnf           text eol=lf
-*.conf          text eol=lf
-*.config        text eol=lf
-*.env           text eol=lf
-.gitattributes  text
-.gitconfig      text
-.htaccess       text eol=lf
-*.lock          text -diff
-composer.lock   text -diff
-symfony.lock    text -diff
-*.toml          text
-*.yaml          text
-*.yml           text
+*.cnf             text
+*.conf            text
+*.config          text
+.editorconfig     text
+*.env             text
+.gitattributes    text
+.gitconfig        text
+.htaccess         text
+*.lock            text -diff
+package.json      text eol=lf
+package-lock.json text eol=lf -diff
+pnpm-lock.yaml    text eol=lf -diff
+.prettierrc       text
+yarn.lock         text -diff
+*.toml            text
+*.yaml            text
+*.yml             text
+browserslist      text
+Makefile          text
+makefile          text
+# Fixes syntax highlighting on GitHub to allow comments
+tsconfig.json     linguist-language=JSON-with-Comments
+
+# Heroku
+Procfile          text
 
 # Graphics
-*.ai            binary
-*.bmp           binary
-*.eps           binary
-*.gif           binary
-*.gifv          binary
-*.ico           binary
-*.jng           binary
-*.jp2           binary
-*.jpg           binary
-*.jpeg          binary
-*.jpx           binary
-*.jxr           binary
-*.pdf           binary
-*.png           binary
-*.psb           binary
-*.psd           binary
+*.ai              binary
+*.bmp             binary
+*.eps             binary
+*.gif             binary
+*.gifv            binary
+*.ico             binary
+*.jng             binary
+*.jp2             binary
+*.jpg             binary
+*.jpeg            binary
+*.jpx             binary
+*.jxr             binary
+*.pdf             binary
+*.png             binary
+*.psb             binary
+*.psd             binary
 # SVG treated as an asset (binary) by default.
-*.svg           text
+*.svg             text
 # If you want to treat it as binary,
 # use the following line instead.
-# *.svg         binary
-*.svgz          binary
-*.tif           binary
-*.tiff          binary
-*.wbmp          binary
-*.webp          binary
+# *.svg           binary
+*.svgz            binary
+*.tif             binary
+*.tiff            binary
+*.wbmp            binary
+*.webp            binary
 
 # Audio
-*.kar           binary
-*.m4a           binary
-*.mid           binary
-*.midi          binary
-*.mp3           binary
-*.ogg           binary
-*.ra            binary
+*.kar             binary
+*.m4a             binary
+*.mid             binary
+*.midi            binary
+*.mp3             binary
+*.ogg             binary
+*.ra              binary
 
 # Video
-*.3gpp          binary
-*.3gp           binary
-*.as            binary
-*.asf           binary
-*.asx           binary
-*.avi           binary
-*.fla           binary
-*.flv           binary
-*.m4v           binary
-*.mng           binary
-*.mov           binary
-*.mp4           binary
-*.mpeg          binary
-*.mpg           binary
-*.ogv           binary
-*.swc           binary
-*.swf           binary
-*.webm          binary
+*.3gpp            binary
+*.3gp             binary
+*.as              binary
+*.asf             binary
+*.asx             binary
+*.avi             binary
+*.fla             binary
+*.flv             binary
+*.m4v             binary
+*.mng             binary
+*.mov             binary
+*.mp4             binary
+*.mpeg            binary
+*.mpg             binary
+*.ogv             binary
+*.swc             binary
+*.swf             binary
+*.webm            binary
 
 # Archives
-*.7z            binary
-*.gz            binary
-*.jar           binary
-*.rar           binary
-*.tar           binary
-*.zip           binary
+*.7z              binary
+*.gz              binary
+*.jar             binary
+*.rar             binary
+*.tar             binary
+*.zip             binary
 
 # Fonts
-*.ttf           binary
-*.eot           binary
-*.otf           binary
-*.woff          binary
-*.woff2         binary
+*.ttf             binary
+*.eot             binary
+*.otf             binary
+*.woff            binary
+*.woff2           binary
 
 # Executables
-*.exe           binary
-*.AppImage      binary
-*.pyc           binary
+*.exe             binary
+*.pyc             binary
+# Prevents massive diffs caused by vendored, minified files
+**/.yarn/releases/**   binary
+**/.yarn/plugins/**    binary
+
+# RC files (like .babelrc or .eslintrc)
+*.*rc             text
 
 # Ignore files (like .npmignore or .gitignore)
-*.*ignore       text
+*.*ignore         text
+
+# Prevents massive diffs from built files
+dist/**           binary
+
+# PHP files
+*.php             text eol=lf diff=php
+*.phpt            text eol=lf diff=php
+*.phtml           text eol=lf diff=html
+*.twig            text eol=lf
+*.phar            binary
+
+# Configuration
+phpcs.xml         text eol=lf
+phpunit.xml       text eol=lf
+phpstan.neon      text eol=lf
+psalm.xml         text eol=lf
+
+# Apply override to all files in the directory
+*.md              linguist-detectable
+
+# PowerShell files
+*.ps1             text eol=crlf
+*.ps1x            text eol=crlf
+*.psm1            text eol=crlf
+*.psd1            text eol=crlf
+*.ps1xml          text eol=crlf
+*.pssc            text eol=crlf
+*.psrc            text eol=crlf
+*.cdxml           text eol=crlf


### PR DESCRIPTION
## ✅ What

Better `.gitattributes` that cover file format cases.

## 🤔 Why

Nothing much in particular. I'm just a big OCD after all.

## 👩‍🔬 How to validate

This one is hard to validate but you can try go to pass PRs and see changes on file format that have special effects (e.g., `.png`, `.txt`).

## 🔖 Related

- GitHub Project ticket: [VOS-15](https://github.com/users/FaceWithDark/projects/4/views/1?pane=issue&itemId=202700471)