### PR TITLE
Tournament page [VOS-14]

### DIFF
--- a/src/Controller/TournamentController.php
+++ b/src/Controller/TournamentController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+
+final class TournamentController extends AbstractController
+{
+	#[Route(
+		path: '/tournament',
+		name: 'tournament_index',
+		methods: ['GET']
+	)]
+	public function index(): Response
+	{
+		return $this->render(
+			view: 'tournament/index.html.twig',
+			parameters: [
+				'controller_name' => 'TournamentController',
+			]
+		);
+	}
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -51,7 +51,7 @@
                 </div>
 
                 <div class="flex flex-row items-center-safe" id="nav-right">
-                    <a href="#" class="text-(--primary)">Tournament</a>
+                    <a href="{{ path(name: 'tournament_index') }}" class="text-(--primary)">Tournament</a>
                 </div>
             </nav>
 

--- a/templates/home/index.html.twig
+++ b/templates/home/index.html.twig
@@ -12,6 +12,6 @@
     </header>
 
     <aside class="flex flex-row justify-center-safe" id="home-page-info">
-        <a href="#" class="text-(--accent) border-solid rounded-full border-2 border-(--border) p-3">Discover more</a>
+        <a href="{{ path(name: 'tournament_index') }}" class="text-(--accent) border-solid rounded-full border-2 border-(--border) p-3">Discover more</a>
     </aside>
 {% endblock %}

--- a/templates/root/index.html.twig
+++ b/templates/root/index.html.twig
@@ -6,12 +6,12 @@
 
 {% block page_contents %}
     <header class="flex flex-col justify-evenly items-center-safe" id="home-page-title">
-        <h1 class="p-12">VOS</h1>
+		<h1 class="p-12">VOS</h1>
         <h2 class="p-12">Manage osu!taiko tournament with ease</h2>
         <h3 class="p-12">A clean website that simplify to your workflow</h3>
     </header>
 
     <aside class="flex flex-row justify-center-safe" id="home-page-info">
-        <a href="#" class="text-(--accent) border-solid rounded-full border-2 border-(--border) p-3">Discover more</a>
+        <a href="{{ path(name: 'tournament_index') }}" class="text-(--accent) border-solid rounded-full border-2 border-(--border) p-3">Discover more</a>
     </aside>
 {% endblock %}

--- a/templates/tournament/index.html.twig
+++ b/templates/tournament/index.html.twig
@@ -1,22 +1,8 @@
-{% extends 'base.html.twig' %}
+{% extends 'tournament/layout.html.twig' %}
 
 
 {% block title %}VOS | Tournament{% endblock %}
 
 
-{% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
-
-<div class="example-wrapper">
-    <h1>Hello {{ controller_name }}! ✅</h1>
-
-    This friendly message is coming from:
-    <ul>
-        <li>Your controller at <code>C:/Users/kutec/Documents/Workplace/VOS Folders/VOS/src/Controller/TournamentController.php</code></li>
-        <li>Your template at <code>C:/Users/kutec/Documents/Workplace/VOS Folders/VOS/templates/tournament/index.html.twig</code></li>
-    </ul>
-</div>
+{% block page_contents %}
 {% endblock %}

--- a/templates/tournament/index.html.twig
+++ b/templates/tournament/index.html.twig
@@ -1,0 +1,22 @@
+{% extends 'base.html.twig' %}
+
+
+{% block title %}VOS | Tournament{% endblock %}
+
+
+{% block body %}
+<style>
+    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
+    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
+</style>
+
+<div class="example-wrapper">
+    <h1>Hello {{ controller_name }}! ✅</h1>
+
+    This friendly message is coming from:
+    <ul>
+        <li>Your controller at <code>C:/Users/kutec/Documents/Workplace/VOS Folders/VOS/src/Controller/TournamentController.php</code></li>
+        <li>Your template at <code>C:/Users/kutec/Documents/Workplace/VOS Folders/VOS/templates/tournament/index.html.twig</code></li>
+    </ul>
+</div>
+{% endblock %}

--- a/templates/tournament/layout.html.twig
+++ b/templates/tournament/layout.html.twig
@@ -1,0 +1,8 @@
+{% extends 'base.html.twig' %}
+
+
+{% block content %}
+    <div class="flex flex-col flex-auto justify-center-safe" id="tournament-page">
+        {% block page_contents %}{% endblock %}
+    </div>
+{% endblock %}

--- a/tests/Controller/TournamentControllerTest.php
+++ b/tests/Controller/TournamentControllerTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class TournamentControllerTest extends WebTestCase
+{
+    public function testIndex(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/tournament');
+
+        self::assertResponseIsSuccessful();
+    }
+}


### PR DESCRIPTION
## ✅ What

New **Tournament page** when accessing the website under `/tournament` path.

## 🤔 Why

Because we have the redirection there on navigation bar, but it can't be used since nothing has been done for **Tournament page** yet. Moreover, our website purposes are to help managing osu!taiko tournament (specifically to VN region) in a much simpler way, and yet we didn't have anything to support this statement yet.

## 👩‍🔬 How to validate

When users visiting the website under `/tournament` path, they'll be greeted with a completely brand new **Tournament page** with minimal information for each tourney being created under **VOS project**.

## 🔖 Related

- GitHub Project ticket:
1. [VOS-14](https://github.com/users/FaceWithDark/projects/4/views/1?pane=issue&itemId=201939643) _(parent ticket)_
2. [VOS-14-1](https://github.com/users/FaceWithDark/projects/4/views/1?pane=issue&itemId=202826468) _(sub-ticket)_
3. [VOS-14-2](https://github.com/users/FaceWithDark/projects/4/views/1?pane=issue&itemId=202826542) _(sub-ticket)_
4. [VOS-14-3](https://github.com/users/FaceWithDark/projects/4/views/1?pane=issue&itemId=202825873) _(sub-ticket)_