### PR TITLE
Inherit navigation bar from other pages [VOS-14-1]

### DIFF
--- a/templates/tournament/index.html.twig
+++ b/templates/tournament/index.html.twig
@@ -1,22 +1,8 @@
-{% extends 'base.html.twig' %}
+{% extends 'tournament/layout.html.twig' %}
 
 
 {% block title %}VOS | Tournament{% endblock %}
 
 
-{% block body %}
-<style>
-    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
-    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
-</style>
-
-<div class="example-wrapper">
-    <h1>Hello {{ controller_name }}! ✅</h1>
-
-    This friendly message is coming from:
-    <ul>
-        <li>Your controller at <code>C:/Users/kutec/Documents/Workplace/VOS Folders/VOS/src/Controller/TournamentController.php</code></li>
-        <li>Your template at <code>C:/Users/kutec/Documents/Workplace/VOS Folders/VOS/templates/tournament/index.html.twig</code></li>
-    </ul>
-</div>
+{% block page_contents %}
 {% endblock %}

--- a/templates/tournament/layout.html.twig
+++ b/templates/tournament/layout.html.twig
@@ -1,0 +1,8 @@
+{% extends 'base.html.twig' %}
+
+
+{% block content %}
+    <div class="flex flex-col flex-auto justify-center-safe" id="tournament-page">
+        {% block page_contents %}{% endblock %}
+    </div>
+{% endblock %}


### PR DESCRIPTION
## ✅ What

Consistent layout for navigation bar component across pages including **Tournament page** under `/tournament` path.

## 🤔 Why

Because navigation bar component doesn't change between top-level pages.

## 👩‍🔬 How to validate

When users visiting the website under `/tournament` path, they'll see the exactly same navigation bar component used for other pages.

## 🔖 Related

- GitHub Project ticket: [VOS-14-1](https://github.com/users/FaceWithDark/projects/4/views/1?pane=issue&itemId=202826468)