### PR TITLE
Minimal content layout on **Tournament page** [VOS-14-2]

### DIFF
--- a/templates/tournament/index.html.twig
+++ b/templates/tournament/index.html.twig
@@ -5,4 +5,12 @@
 
 
 {% block page_contents %}
+    <header class="flex flex-row justify-center-safe" id="home-page-title">
+        <!--
+            TODO:
+            when search filter feature get implemented, this title name will get
+            dynamically appended based on the value provided to the filter
+        -->
+        <h1 class="p-12">VOS Tourney</h1>
+    </header>
 {% endblock %}


### PR DESCRIPTION
## ✅ What

Minimal layout for content section on **Tournament page** under `/tournament` path.

## 🤔 Why

Because there's literally nothing on that page right now besides the navigation bar.

## 👩‍🔬 How to validate

When users visiting the website under `/tournament` path, they'll be seeing a very minimal layout for **Tournament page**.

## 🔖 Related

- GitHub Project ticket: [VOS-14-2](https://github.com/users/FaceWithDark/projects/4/views/1?pane=issue&itemId=202826542)